### PR TITLE
Add credit purchase flow

### DIFF
--- a/app/_components/button.tsx
+++ b/app/_components/button.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import Link from 'next/link'
 import { ComponentProps, useState } from 'react'
 import { cn } from '../utils/classnames'

--- a/app/_components/studio/new-canvas.tsx
+++ b/app/_components/studio/new-canvas.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/app/utils/classnames'
 import { usePostProcessingStatus } from '@/app/utils/use-post-processing-status'
 import Image from 'next/image'
 import { memo } from 'react'
-import { Button } from '../button'
+import { Button, ButtonLink } from '../button'
 import { useRouter } from 'next/navigation'
 import RetroLoader from '../loader'
 import { Pill } from '../pill'
@@ -159,19 +159,26 @@ function Loading() {
 
 function Error() {
   const { error } = useNewCanvas()
+  const isNoCredits = error === 'You have no credits left.'
 
   return (
     <div className='flex flex-col items-center justify-center h-full'>
       <div className='flex items-center flex-col gap-3'>
         <p className='text-lg text-dark-hover leading-4'>
-          something went wrong:
+          {isNoCredits ? 'out of credits' : 'something went wrong:'}
         </p>
         <p className='text-sm bg-medium pixel-corners px-2 py-1 w-fit text-center mx-4'>
           {error || 'Unexpected error'}
         </p>
-        <p className='text-xs text-shadow w-fit'>
-          note: credits will not be deducted
-        </p>
+        {isNoCredits ? (
+          <ButtonLink href='/credits' className='text-xs'>
+            Get More Credits
+          </ButtonLink>
+        ) : (
+          <p className='text-xs text-shadow w-fit'>
+            note: credits will not be deducted
+          </p>
+        )}
       </div>
     </div>
   )

--- a/app/_components/user/profile.client.tsx
+++ b/app/_components/user/profile.client.tsx
@@ -67,6 +67,11 @@ function UserProfileInternal({
             </DropdownMenu.Label>
           </div>
           <Credits credits={credits} />
+          <DropdownMenu.Item asChild textValue='Buy Credits'>
+            <ButtonLink className='w-full' href='/credits'>
+              Buy Credits
+            </ButtonLink>
+          </DropdownMenu.Item>
           <DropdownMenu.Separator />
           {NAV_LINKS.map(({ label, href }) => (
             <DropdownMenu.Item asChild textValue={label} key={href}>

--- a/app/credits/packs.client.tsx
+++ b/app/credits/packs.client.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { checkout } from '@/lib/auth/client'
+import Image from 'next/image'
+import { useState } from 'react'
+import { Button } from '../_components/button'
+
+interface CreditPack {
+  name: string
+  credits: number
+  displayPrice: string
+  productId: string
+  popular: boolean
+}
+
+export function CreditPacks({ packs }: { packs: CreditPack[] }) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 w-full pt-4">
+      {packs.map((pack) => (
+        <PackCard key={pack.name} pack={pack} />
+      ))}
+    </div>
+  )
+}
+
+function PackCard({ pack }: { pack: CreditPack }) {
+  const [loading, setLoading] = useState(false)
+
+  async function handleBuy() {
+    setLoading(true)
+    try {
+      await checkout({
+        products: [pack.productId],
+      })
+    } catch {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="relative">
+      {pack.popular && (
+        <span className="absolute -top-3 left-1/2 -translate-x-1/2 z-10 bg-foreground text-background text-xs px-2 py-0.5 pixel-corners pixel-border-foreground">
+          Best Value
+        </span>
+      )}
+      <div className="flex flex-col items-center gap-4 p-6 pixel-corners pixel-border-foreground bg-background">
+        <p className="text-xl">{pack.name}</p>
+        <div className="flex items-center gap-2">
+          <Image src="/coin.svg" width={24} height={24} alt="Credit" />
+          <p className="text-2xl">
+            {pack.credits} Credit{pack.credits === 1 ? '' : 's'}
+          </p>
+        </div>
+        <p className="text-lg text-shadow">{pack.displayPrice}</p>
+        <Button
+          className="w-full"
+          onClick={handleBuy}
+          disabled={loading}
+        >
+          {loading ? 'Redirecting...' : 'Buy'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/app/credits/page.tsx
+++ b/app/credits/page.tsx
@@ -1,0 +1,56 @@
+import { credits } from '@/app/utils/credits'
+import { Credits } from '@/app/_components/user/credits'
+import { getSession } from '@/lib/auth/session'
+import { CREDIT_PACKS } from '@/lib/constants'
+import Image from 'next/image'
+import { redirect } from 'next/navigation'
+import { Suspense } from 'react'
+import { CreditPacks } from './packs.client'
+
+export default function CreditsPage() {
+  const env =
+    process.env.NODE_ENV === 'production' ? 'production' : 'sandbox'
+  const packs = CREDIT_PACKS.map((pack) => ({
+    name: pack.name,
+    credits: pack.credits,
+    displayPrice: pack.displayPrice,
+    productId: pack.productId[env],
+    popular: 'popular' in pack ? pack.popular : false,
+  }))
+
+  return (
+    <div className="flex flex-col items-center gap-8 py-12 px-4 w-full max-w-3xl mx-auto">
+      <div className="flex flex-col items-center gap-4">
+        <h1 className="text-3xl">Get Credits</h1>
+        <p className="text-sm text-shadow">
+          Credits are used to generate pixel art icons.
+        </p>
+        <Suspense fallback={<CreditsSkeleton />}>
+          <CurrentCredits />
+        </Suspense>
+      </div>
+      <CreditPacks packs={packs} />
+    </div>
+  )
+}
+
+function CreditsSkeleton() {
+  return (
+    <div className="flex gap-2 items-center bg-medium pixel-corners pixel-border-medium p-2 w-full">
+      <Image src="/coin.svg" width={24} height={24} alt="Golden coin" />
+      <div className="h-4 w-20 bg-light-shadow animate-pulse" />
+    </div>
+  )
+}
+
+async function CurrentCredits() {
+  const session = await getSession()
+
+  if (!session) {
+    redirect('/')
+  }
+
+  const currentCredits = await credits.get(session.user.id)
+
+  return <Credits credits={currentCredits} />
+}

--- a/app/credits/success/page.tsx
+++ b/app/credits/success/page.tsx
@@ -1,0 +1,48 @@
+import { credits } from '@/app/utils/credits'
+import { Credits } from '@/app/_components/user/credits'
+import { ButtonLink } from '@/app/_components/button'
+import { getSession } from '@/lib/auth/session'
+import Image from 'next/image'
+import { redirect } from 'next/navigation'
+import { Suspense } from 'react'
+
+export default function CreditsSuccess() {
+  return (
+    <div className="flex flex-col items-center gap-8 py-12 px-4 w-full max-w-md mx-auto">
+      <div className="flex flex-col items-center gap-4">
+        <h1 className="text-3xl">Credits Added!</h1>
+        <p className="text-sm text-shadow">
+          Your credits have been added to your account.
+        </p>
+        <Suspense fallback={<CreditsSkeleton />}>
+          <CurrentCredits />
+        </Suspense>
+      </div>
+      <div className="flex gap-4">
+        <ButtonLink href="/">Create</ButtonLink>
+        <ButtonLink href="/studio">Studio</ButtonLink>
+      </div>
+    </div>
+  )
+}
+
+function CreditsSkeleton() {
+  return (
+    <div className="flex gap-2 items-center bg-medium pixel-corners pixel-border-medium p-2 w-full">
+      <Image src="/coin.svg" width={24} height={24} alt="Golden coin" />
+      <div className="h-4 w-20 bg-light-shadow animate-pulse" />
+    </div>
+  )
+}
+
+async function CurrentCredits() {
+  const session = await getSession()
+
+  if (!session) {
+    redirect('/')
+  }
+
+  const currentCredits = await credits.get(session.user.id)
+
+  return <Credits credits={currentCredits} />
+}

--- a/lib/auth/client.ts
+++ b/lib/auth/client.ts
@@ -28,3 +28,22 @@ export const signInWithGoogle = ({
 }
 
 export const { signOut, useSession } = authClient
+
+export async function checkout({ products }: { products: string[] }) {
+  const res = await fetch(`${getBaseUrl()}/api/auth/checkout`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ products }),
+  })
+
+  if (!res.ok) {
+    throw new Error('Checkout failed')
+  }
+
+  const data = await res.json()
+
+  if (data.url) {
+    window.location.href = data.url
+  }
+}

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -1,4 +1,4 @@
-import { polar, portal, usage } from '@polar-sh/better-auth'
+import { checkout, polar, portal, usage } from '@polar-sh/better-auth'
 import { Polar } from '@polar-sh/sdk'
 import { betterAuth } from 'better-auth'
 import { nextCookies } from 'better-auth/next-js'
@@ -63,7 +63,11 @@ export const auth = betterAuth({
     polar({
       client,
       createCustomerOnSignUp: true,
-      use: [portal(), usage()],
+      use: [
+        portal(),
+        usage(),
+        checkout({ successUrl: '/credits/success' }),
+      ],
     }),
   ],
   session: {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -30,6 +30,40 @@ Style guide:
 
 The reference images show exactly what we want: simple, blocky, charming pixel art icons. Please match that same level of simplicity.`
 
+export const CREDIT_PACKS = [
+  {
+    name: 'Tiny',
+    credits: 5,
+    price: 499,
+    displayPrice: '$4.99',
+    productId: {
+      sandbox: '704e3a00-9377-460e-8a82-f0c0dd9d7667',
+      production: '7c7322ec-2f43-4b83-bce4-237ed9ea2e72',
+    },
+  },
+  {
+    name: 'Medium',
+    credits: 20,
+    price: 1499,
+    displayPrice: '$14.99',
+    productId: {
+      sandbox: 'e21fc251-dee3-42bd-9cf1-bc0f53679766',
+      production: '7e95db23-fa84-477d-9ac9-1c167734886a',
+    },
+    popular: true,
+  },
+  {
+    name: 'Mega',
+    credits: 60,
+    price: 3999,
+    displayPrice: '$39.99',
+    productId: {
+      sandbox: 'a8b5a688-98b4-4d7a-8367-b8e47ade4786',
+      production: 'f76b4d47-2458-4d4c-9502-e8c2b457678a',
+    },
+  },
+] as const
+
 export const NAV_LINKS = [
   { href: '/', label: 'Home', isActive: true },
   { href: '/explore', label: 'Explore' },


### PR DESCRIPTION
## Summary
- Add 3 credit packs (Tiny 5/$4.99, Medium 20/$14.99, Mega 60/$39.99) with Polar checkout integration
- Create `/credits` purchase page and `/credits/success` confirmation page with Suspense streaming
- Add "Buy Credits" link in profile dropdown and "Get More Credits" CTA on no-credits error state
- Wire up Better Auth `checkout()` server plugin; client uses plain fetch to avoid `node:async_hooks` bundle issue

## Test plan
- [ ] Sign in → navigate to `/credits` → verify pack cards render with correct prices
- [ ] Click "Buy" → complete Polar sandbox checkout → verify redirect to `/credits/success`
- [ ] Verify credit count updates after purchase
- [ ] Verify "Buy Credits" appears in profile dropdown
- [ ] Generate with 0 credits → verify "Get More Credits" link appears
- [ ] Set `POLAR_CREDIT_METER=999cb3b1-19f7-4bd6-9830-f75c55809bcc` in Vercel for production

🤖 Generated with [Claude Code](https://claude.com/claude-code)