### PR TITLE
Add pixel deletion functionality to studio

### DIFF
--- a/app/_components/studio/pixels/canvas.client.tsx
+++ b/app/_components/studio/pixels/canvas.client.tsx
@@ -565,6 +565,7 @@ export function Canvas({
           Subtle imperfections are expected when mapping to the grid-based
           editor
         </p>
+
       </div>
     </div>
   )

--- a/app/_components/studio/pixels/delete-button.tsx
+++ b/app/_components/studio/pixels/delete-button.tsx
@@ -25,7 +25,9 @@ export function DeletePixelButton({ pixelId }: { pixelId: string }) {
   return (
     <AlertDialog.Root open={open} onOpenChange={setOpen}>
       <AlertDialog.Trigger asChild>
-        <Button variant='dark'>Delete</Button>
+        <button className='text-xs text-medium hover:text-accent cursor-pointer transition-colors'>
+          Delete
+        </button>
       </AlertDialog.Trigger>
       <AlertDialog.Portal>
         <AlertDialog.Overlay className='fixed inset-0 bg-black/40 z-50' />

--- a/app/_components/studio/pixels/delete-button.tsx
+++ b/app/_components/studio/pixels/delete-button.tsx
@@ -33,7 +33,7 @@ export function DeletePixelButton({
       <AlertDialog.Trigger asChild>{children}</AlertDialog.Trigger>
       <AlertDialog.Portal>
         <AlertDialog.Overlay className='fixed inset-0 bg-black/40 z-50' />
-        <AlertDialog.Content className='fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-background pixel-corners pixel-border-light-shadow p-6 z-50 w-80 flex flex-col gap-4'>
+        <AlertDialog.Content className='fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-background pixel-corners pixel-border-foreground p-6 z-50 w-80 flex flex-col gap-4'>
           <AlertDialog.Title className='text-lg text-foreground'>
             Delete pixel?
           </AlertDialog.Title>

--- a/app/_components/studio/pixels/delete-button.tsx
+++ b/app/_components/studio/pixels/delete-button.tsx
@@ -34,10 +34,10 @@ export function DeletePixelButton({
       <AlertDialog.Portal>
         <AlertDialog.Overlay className='fixed inset-0 bg-black/40 z-50' />
         <AlertDialog.Content className='fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-background pixel-corners pixel-border-light-shadow p-6 z-50 w-80 flex flex-col gap-4'>
-          <AlertDialog.Title className='text-lg text-accent'>
+          <AlertDialog.Title className='text-lg text-foreground'>
             Delete pixel?
           </AlertDialog.Title>
-          <AlertDialog.Description className='text-sm text-medium'>
+          <AlertDialog.Description className='text-sm text-shadow'>
             This action cannot be undone. The pixel and all its versions will be
             permanently deleted.
           </AlertDialog.Description>

--- a/app/_components/studio/pixels/delete-button.tsx
+++ b/app/_components/studio/pixels/delete-button.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { AlertDialog } from 'radix-ui'
+import { Button } from '@/app/_components/button'
+import { deletePixelAction } from './delete'
+import { toast } from 'sonner'
+import { getError } from '@/lib/error'
+import type { ErrorCode } from '@/lib/error'
+
+export function DeletePixelButton({ pixelId }: { pixelId: string }) {
+  const [open, setOpen] = useState(false)
+  const [isPending, startTransition] = useTransition()
+
+  function handleDelete() {
+    startTransition(async () => {
+      const result = await deletePixelAction(pixelId)
+      if (result?.error) {
+        toast.error(getError(result.error as ErrorCode))
+        setOpen(false)
+      }
+    })
+  }
+
+  return (
+    <AlertDialog.Root open={open} onOpenChange={setOpen}>
+      <AlertDialog.Trigger asChild>
+        <Button variant='dark'>Delete</Button>
+      </AlertDialog.Trigger>
+      <AlertDialog.Portal>
+        <AlertDialog.Overlay className='fixed inset-0 bg-black/40 z-50' />
+        <AlertDialog.Content className='fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-background pixel-corners pixel-border-light-shadow p-6 z-50 w-80 flex flex-col gap-4'>
+          <AlertDialog.Title className='text-lg text-accent'>
+            Delete pixel?
+          </AlertDialog.Title>
+          <AlertDialog.Description className='text-sm text-medium'>
+            This action cannot be undone. The pixel and all its versions will be
+            permanently deleted.
+          </AlertDialog.Description>
+          <div className='flex gap-2 justify-end'>
+            <AlertDialog.Cancel asChild>
+              <Button variant='primary' disabled={isPending}>
+                Cancel
+              </Button>
+            </AlertDialog.Cancel>
+            <AlertDialog.Action asChild>
+              <Button
+                variant='dark'
+                onClick={handleDelete}
+                disabled={isPending}
+              >
+                {isPending ? 'Deleting...' : 'Delete'}
+              </Button>
+            </AlertDialog.Action>
+          </div>
+        </AlertDialog.Content>
+      </AlertDialog.Portal>
+    </AlertDialog.Root>
+  )
+}

--- a/app/_components/studio/pixels/delete-button.tsx
+++ b/app/_components/studio/pixels/delete-button.tsx
@@ -8,7 +8,13 @@ import { toast } from 'sonner'
 import { getError } from '@/lib/error'
 import type { ErrorCode } from '@/lib/error'
 
-export function DeletePixelButton({ pixelId }: { pixelId: string }) {
+export function DeletePixelButton({
+  pixelId,
+  children,
+}: {
+  pixelId: string
+  children: React.ReactNode
+}) {
   const [open, setOpen] = useState(false)
   const [isPending, startTransition] = useTransition()
 
@@ -24,11 +30,7 @@ export function DeletePixelButton({ pixelId }: { pixelId: string }) {
 
   return (
     <AlertDialog.Root open={open} onOpenChange={setOpen}>
-      <AlertDialog.Trigger asChild>
-        <button className='text-xs text-medium hover:text-accent cursor-pointer transition-colors'>
-          Delete
-        </button>
-      </AlertDialog.Trigger>
+      <AlertDialog.Trigger asChild>{children}</AlertDialog.Trigger>
       <AlertDialog.Portal>
         <AlertDialog.Overlay className='fixed inset-0 bg-black/40 z-50' />
         <AlertDialog.Content className='fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-background pixel-corners pixel-border-light-shadow p-6 z-50 w-80 flex flex-col gap-4'>

--- a/app/_components/studio/pixels/delete.ts
+++ b/app/_components/studio/pixels/delete.ts
@@ -1,0 +1,36 @@
+'use server'
+
+import { authorizeRequest } from '@/lib/auth/request'
+import { deletePixel, isPixelOwner } from '@/lib/db/queries'
+import { ERROR_CODES } from '@/lib/error'
+import { revalidateTag } from 'next/cache'
+import { redirect } from 'next/navigation'
+
+export async function deletePixelAction(pixelId: string) {
+  const authorized = await authorizeRequest()
+
+  if (!authorized.success) {
+    return { error: ERROR_CODES.UNAUTHORIZED, success: false }
+  }
+
+  const ownsPixel = await isPixelOwner(pixelId, authorized.user.id)
+  if (!ownsPixel) {
+    return { error: ERROR_CODES.UNAUTHORIZED, success: false }
+  }
+
+  try {
+    const deletedId = await deletePixel(pixelId)
+
+    if (!deletedId) {
+      return { error: ERROR_CODES.UNEXPECTED_ERROR, success: false }
+    }
+
+    revalidateTag(`pixel:${pixelId}`, { expire: 0 })
+    revalidateTag(`getLatestPixelIds:${authorized.user.id}`, { expire: 0 })
+    revalidateTag('explore-pixels', { expire: 0 })
+  } catch (error) {
+    return { error: ERROR_CODES.UNEXPECTED_ERROR, success: false }
+  }
+
+  redirect('/studio')
+}

--- a/app/p/[id]/owner.tsx
+++ b/app/p/[id]/owner.tsx
@@ -1,7 +1,9 @@
+import { Button } from '@/app/_components/button'
 import { Pill } from '@/app/_components/pill'
 import { Canvas } from '@/app/_components/studio/pixels/canvas.client'
 import { DeletePixelButton } from '@/app/_components/studio/pixels/delete-button'
 import { getLatestPixelVersion } from '@/lib/db/queries'
+import Image from 'next/image'
 import { UneditedImage } from './unedited-image'
 
 export function MyPixelView({
@@ -21,14 +23,26 @@ export function MyPixelView({
 
   return (
     <div className='flex flex-col gap-6 w-full p-6 items-center'>
-      <div className='align-left w-full bg-light-shadow p-2 pixel-corners pixel-border-light-shadow text-highlight flex flex-col gap-2'>
-        <div className='flex justify-between items-start'>
-          <h2 className='text-2xl'>{pixel.prompt}</h2>
-          <DeletePixelButton pixelId={pixel.id} />
-        </div>
-        <div className='flex gap-2'>
+      <div className='flex flex-col sm:flex-row sm:items-center gap-2 w-full'>
+        <h2 className='text-2xl text-highlight truncate'>{pixel.prompt}</h2>
+        <div className='flex gap-2 items-center sm:ml-auto shrink-0'>
           <Pill variant='dark'>{pixel.createdAt.toLocaleDateString()}</Pill>
           <Pill variant='dark'>{pixel.createdAt.toLocaleTimeString()}</Pill>
+          <DeletePixelButton pixelId={pixel.id}>
+            <Button
+              aria-label='Delete pixel'
+              iconOnly
+              variant='primary'
+              className='size-7!'
+            >
+              <Image
+                src='/editor/trash.png'
+                alt='Delete'
+                width={16}
+                height={16}
+              />
+            </Button>
+          </DeletePixelButton>
         </div>
       </div>
 

--- a/app/p/[id]/owner.tsx
+++ b/app/p/[id]/owner.tsx
@@ -1,5 +1,6 @@
 import { Pill } from '@/app/_components/pill'
 import { Canvas } from '@/app/_components/studio/pixels/canvas.client'
+import { DeletePixelButton } from '@/app/_components/studio/pixels/delete-button'
 import { getLatestPixelVersion } from '@/lib/db/queries'
 import { UneditedImage } from './unedited-image'
 
@@ -22,9 +23,10 @@ export function MyPixelView({
     <div className='flex flex-col gap-6 w-full p-6 items-center'>
       <div className='align-left w-full bg-light-shadow p-2 pixel-corners pixel-border-light-shadow text-highlight flex flex-col gap-2'>
         <h2 className='text-2xl'>{pixel.prompt}</h2>
-        <div className='flex gap-2'>
+        <div className='flex gap-2 items-center'>
           <Pill variant='dark'>{pixel.createdAt.toLocaleDateString()}</Pill>
           <Pill variant='dark'>{pixel.createdAt.toLocaleTimeString()}</Pill>
+          <DeletePixelButton pixelId={pixel.id} />
         </div>
       </div>
 

--- a/app/p/[id]/owner.tsx
+++ b/app/p/[id]/owner.tsx
@@ -24,7 +24,7 @@ export function MyPixelView({
   return (
     <div className='flex flex-col gap-6 w-full p-6 items-center'>
       <div className='flex flex-col sm:flex-row sm:items-center gap-2 w-full'>
-        <h2 className='text-2xl text-highlight truncate'>{pixel.prompt}</h2>
+        <h2 className='text-2xl text-accent truncate'>{pixel.prompt}</h2>
         <div className='flex gap-2 items-center sm:ml-auto shrink-0'>
           <Pill variant='dark'>{pixel.createdAt.toLocaleDateString()}</Pill>
           <Pill variant='dark'>{pixel.createdAt.toLocaleTimeString()}</Pill>
@@ -33,13 +33,13 @@ export function MyPixelView({
               aria-label='Delete pixel'
               iconOnly
               variant='primary'
-              className='size-7!'
+              className='size-9!'
             >
               <Image
                 src='/editor/trash.png'
                 alt='Delete'
-                width={16}
-                height={16}
+                width={20}
+                height={20}
               />
             </Button>
           </DeletePixelButton>

--- a/app/p/[id]/owner.tsx
+++ b/app/p/[id]/owner.tsx
@@ -22,11 +22,13 @@ export function MyPixelView({
   return (
     <div className='flex flex-col gap-6 w-full p-6 items-center'>
       <div className='align-left w-full bg-light-shadow p-2 pixel-corners pixel-border-light-shadow text-highlight flex flex-col gap-2'>
-        <h2 className='text-2xl'>{pixel.prompt}</h2>
-        <div className='flex gap-2 items-center'>
+        <div className='flex justify-between items-start'>
+          <h2 className='text-2xl'>{pixel.prompt}</h2>
+          <DeletePixelButton pixelId={pixel.id} />
+        </div>
+        <div className='flex gap-2'>
           <Pill variant='dark'>{pixel.createdAt.toLocaleDateString()}</Pill>
           <Pill variant='dark'>{pixel.createdAt.toLocaleTimeString()}</Pill>
-          <DeletePixelButton pixelId={pixel.id} />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
This PR adds the ability for users to delete their own pixels from the studio. It includes a new delete button with a confirmation dialog and server-side authorization checks to ensure only pixel owners can delete their work.

## Key Changes
- **New `DeletePixelButton` component** (`delete-button.tsx`): A client-side component that renders a delete button and confirmation dialog using Radix UI's AlertDialog. Handles the deletion flow with loading states and error handling via toast notifications.
- **New `deletePixelAction` server action** (`delete.ts`): Validates user authorization and pixel ownership before deletion. Clears relevant cache tags and redirects to studio on success.
- **Updated pixel owner view** (`owner.tsx`): Integrated the DeletePixelButton into the pixel details header, positioned alongside the creation date pills.

## Implementation Details
- Authorization is enforced at the server action level with both user authentication and pixel ownership checks
- Cache revalidation targets the specific pixel, user's pixel list, and explore page to keep data fresh
- User is redirected to `/studio` after successful deletion
- Error handling provides user-friendly feedback through toast notifications
- Loading state prevents duplicate submissions during the deletion process

https://claude.ai/code/session_016GuwFsTQVsQgCcpFxTTH1x