### PR TITLE
Add prompt input skeleton to prevent layout shift

### DIFF
--- a/app/_components/studio/pixels/skeleton.tsx
+++ b/app/_components/studio/pixels/skeleton.tsx
@@ -4,23 +4,32 @@ import { sharedClasses } from '../constants'
 
 export function CanvasSkeleton() {
   return (
-    <div className={sharedClasses}>
-      <div
-        className={cn(
-          'flex items-center justify-center ',
-          'border-3 border-shadow border-r-background border-b-background',
-          'w-full h-auto md:h-full md:w-auto aspect-square bg-white'
-        )}
-      />
-      <div className='min-h-36 md:min-h-auto min-w-auto md:min-w-36 flex flex-col gap-3 select-none'>
-        <div className='flex gap-1 text-xs'>
-          <Pill className='flex-1 truncate whitespace-nowrap' variant='dark'>
-            ***
-          </Pill>
-          <Pill className='w-fit'>**/**/****</Pill>
-        </div>
+    <div className='flex flex-col items-center justify-center gap-16'>
+      <div className={sharedClasses}>
+        <div
+          className={cn(
+            'flex items-center justify-center ',
+            'border-3 border-shadow border-r-background border-b-background',
+            'w-full h-auto md:h-full md:w-auto aspect-square bg-white'
+          )}
+        />
+        <div className='min-h-36 md:min-h-auto min-w-auto md:min-w-36 flex flex-col gap-3 select-none'>
+          <div className='flex gap-1 text-xs'>
+            <Pill className='flex-1 truncate whitespace-nowrap' variant='dark'>
+              ***
+            </Pill>
+            <Pill className='w-fit'>**/**/****</Pill>
+          </div>
 
-        <div className='flex flex-col w-full p-2 border-3 border-white border-r-shadow border-b-shadow h-[142px]' />
+          <div className='flex flex-col w-full p-2 border-3 border-white border-r-shadow border-b-shadow h-[142px]' />
+        </div>
+      </div>
+      {/* Prompt input skeleton to prevent CLS */}
+      <div className='flex flex-col py-2 min-w-[250px] w-full xs:max-w-[700px] mb-10'>
+        <div className='flex flex-col gap-2.5 pixel-corners p-2 bg-black pixel-border-black'>
+          <div className='w-full bg-accent h-10' />
+          <div className='flex items-center h-[38px]' />
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
Updated the canvas skeleton component to include a placeholder for the prompt input section, preventing cumulative layout shift (CLS) when the component fully loads.

## Changes
- Wrapped existing skeleton content in a centered flex container with gap spacing
- Added a new skeleton section that mirrors the prompt input layout with:
  - A placeholder for the input field (accent-colored bar)
  - A placeholder for the submit button area
  - Matching styling with pixel corners and black border to align with the final UI
- This ensures the layout remains stable during the loading phase, improving perceived performance and user experience

## Implementation Details
- The new skeleton uses the same visual styling (pixel-corners, pixel-border-black) as the actual prompt input component
- Dimensions and spacing are carefully matched to the real component to prevent any visual jumping when content loads
- The skeleton is positioned below the canvas area with appropriate margin and width constraints

https://claude.ai/code/session_01P5N1cPEbmXQecz2k58dkyP